### PR TITLE
fix: set de atributo de garantia no repositório de bens

### DIFF
--- a/src/gui/TelaAnalisePropostaController.java
+++ b/src/gui/TelaAnalisePropostaController.java
@@ -1,5 +1,6 @@
 package gui;
 
+import exceptions.BensInexistenteException;
 import exceptions.EmprestimoDuplicadoException;
 import exceptions.PropostaInvalidaException;
 import gerenciamento.SessionManager;
@@ -84,6 +85,8 @@ public class TelaAnalisePropostaController {
                     (Empregado) SessionManager.getInstance().getPessoaSessao());
         } catch (EmprestimoDuplicadoException e) {
             this.gerarAlertaErro("Erro de Empréstimo","Empréstimo Duplicado", e.getMessage());
+        } catch (BensInexistenteException e) {
+            this.gerarAlertaErro("Erro de Empréstimo", "Bens de Garantia Inexistente", e.getMessage());
         }
         this.btnCriarEmprestimo.disableProperty().set(true);
     }

--- a/src/negocio/ControladorBENS.java
+++ b/src/negocio/ControladorBENS.java
@@ -7,6 +7,7 @@ import negocio.beans.Bens;
 import negocio.beans.CategoriaBens;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class ControladorBENS {
     private Repositorio<Bens> repoBENS;
@@ -175,6 +176,30 @@ public class ControladorBENS {
         }if(!existevalor)  throw new PessoaInexistenteException("Cliente Não existe!");
 
         return valor;
+    }
+
+    /**
+     * Método que, por meio de lista de Bens, filtra os bens e os aplica como garantia; ou seja realiza o set do
+     * atributo de {@code garantia} como {@code true}.
+     *
+     * @param bensAntigos se refere a lista de Bens ao qual será aplicado como garantia.
+     * @throws BensInexistenteException poderá acontecer caso haja um BENS que não pertença ao repositório de BENS
+     */
+    public void aplicarBensComoGarantia(List<Bens> bensAntigos) throws BensInexistenteException {
+        if (bensAntigos == null) return;
+
+        List<Bens> bensComoGarantia = bensAntigos.stream()
+                                                 .peek(bens -> {bens.setGarantia(true);})
+                                                 .collect(Collectors.toList());
+        for (Bens bensAntigo : bensAntigos) {
+            for (Bens bensNovos : bensComoGarantia) {
+                try {
+                    this.alterarBens(bensAntigo, bensNovos);
+                } catch (BensInexistenteException e) {
+                    throw new BensInexistenteException("Há Bens de garantia que não existem!");
+                }
+            }
+        }
     }
 
     /**

--- a/src/negocio/ControladorEmprestimo.java
+++ b/src/negocio/ControladorEmprestimo.java
@@ -2,6 +2,7 @@ package negocio;
 
 import dados.Repositorio;
 import dados.RepositorioCRUD;
+import exceptions.BensInexistenteException;
 import exceptions.EmprestimoDuplicadoException;
 import exceptions.EmprestimoInexistenteException;
 import exceptions.ObjetoDuplicadoException;
@@ -39,7 +40,8 @@ public class ControladorEmprestimo {
      * @throws EmprestimoDuplicadoException poderá acontecer caso o {@code Emprestimo} já esteja cadastro no sistema de
      * {@code repoEmprestimo}.
      */
-    public void criarEmprestimo(Proposta proposta, Empregado empregado) throws EmprestimoDuplicadoException {
+    public void criarEmprestimo(Proposta proposta, Empregado empregado) throws EmprestimoDuplicadoException,
+            BensInexistenteException {
         //Evitar criação de empréstimo fantasma
         if (proposta == null || empregado == null) return;
 
@@ -61,6 +63,7 @@ public class ControladorEmprestimo {
 
         try {
             repoEmprestimo.inserir(emprestimo);
+            Fachada.getInstance().aplicarBensComoGarantia(proposta.getGarantia());
             contadorProtocolo++;
         } catch (ObjetoDuplicadoException e) {
             throw new EmprestimoDuplicadoException("Parece que esse empréstimo já existe!");

--- a/src/negocio/Fachada.java
+++ b/src/negocio/Fachada.java
@@ -101,7 +101,8 @@ public class Fachada implements SistemaEmprestimosBens {
     }
 
     @Override
-    public void criarEmprestimo(Proposta proposta, Empregado empregado) throws EmprestimoDuplicadoException {
+    public void criarEmprestimo(Proposta proposta, Empregado empregado) throws EmprestimoDuplicadoException,
+            BensInexistenteException {
         emprestimos.criarEmprestimo(proposta, empregado);
     }
 

--- a/src/negocio/Fachada.java
+++ b/src/negocio/Fachada.java
@@ -86,6 +86,11 @@ public class Fachada implements SistemaEmprestimosBens {
     }
 
     @Override
+    public void aplicarBensComoGarantia(List<Bens> bensAntigos) throws BensInexistenteException {
+        this.bens.aplicarBensComoGarantia(bensAntigos);
+    }
+
+    @Override
     public void alterarBens(Bens bensAntigo, Bens bensNovo) throws BensInexistenteException {
         bens.alterarBens(bensAntigo, bensNovo);
     }

--- a/src/negocio/SistemaEmprestimosBens.java
+++ b/src/negocio/SistemaEmprestimosBens.java
@@ -82,6 +82,15 @@ public interface SistemaEmprestimosBens {
     double calcularValorBensCliente(long uidCliente) throws PessoaInexistenteException;
 
     /**
+     * Método que, por meio de lista de Bens, filtra os bens e os aplica como garantia; ou seja realiza o set do
+     * atributo de {@code garantia} como {@code true}.
+     *
+     * @param bensAntigos se refere a lista de Bens ao qual será aplicado como garantia.
+     * @throws BensInexistenteException poderá acontecer caso haja um BENS que não pertença ao repositório de BENS
+     */
+    void aplicarBensComoGarantia(List<Bens> bensAntigos) throws BensInexistenteException;
+
+    /**
      * Método que altera um bem por outro no repositório
      *
      * @param bensAntigo bem inicialmente cadastrado.

--- a/src/negocio/SistemaEmprestimosBens.java
+++ b/src/negocio/SistemaEmprestimosBens.java
@@ -118,7 +118,8 @@ public interface SistemaEmprestimosBens {
      * @throws EmprestimoDuplicadoException poderá acontecer caso o {@code Emprestimo} já esteja cadastro no sistema de
      *                                      {@code repoEmprestimo}.
      */
-    void criarEmprestimo(Proposta proposta, Empregado empregado) throws EmprestimoDuplicadoException;
+    void criarEmprestimo(Proposta proposta, Empregado empregado) throws EmprestimoDuplicadoException,
+            BensInexistenteException;
 
     /**
      * Método que faz a busca de um {@code Emprestimo} no repositório de Empréstimos por meio de um número de protocolo.


### PR DESCRIPTION
## Descrição Rápida

Fixes #90 

Há a necessidade de se _setar_ o atributo de `garantia` no repositório de Bens, como forma de atualizar os bens cadastrados no sistema no momento que um empréstimo é criado, dessa forma é possível utilizar métodos que listem apenas bens aprovados.

## Documentação

### Método `aplicarBensComoGarantia()`

```java
    /**
     * Método que, por meio de lista de Bens, filtra os bens e os aplica como garantia; ou seja realiza o set do
     * atributo de {@code garantia} como {@code true}.
     *
     * @param bensAntigos se refere a lista de Bens ao qual será aplicado como garantia.
     * @throws BensInexistenteException poderá acontecer caso haja um BENS que não pertença ao repositório de BENS
     */
     public void aplicarBensComoGarantia(List<Bens> bensAntigos) throws BensInexistenteException
```